### PR TITLE
Add HDF5 dataset connector

### DIFF
--- a/sostrades_core/datasets/datasets_connectors/datasets_connector_factory.py
+++ b/sostrades_core/datasets/datasets_connectors/datasets_connector_factory.py
@@ -44,6 +44,9 @@ from sostrades_core.datasets.datasets_connectors.local_repository_datasets_conne
 from sostrades_core.datasets.datasets_connectors.sospickle_datasets_connector import (
     SoSPickleDatasetsConnector,
 )
+from sostrades_core.datasets.datasets_connectors.hdf5_datasets_connector import (
+    HDF5DatasetsConnector,
+)
 from sostrades_core.tools.metaclasses.no_instance import NoInstanceMeta
 
 
@@ -60,6 +63,7 @@ class DatasetConnectorType(Enum):
     SoSpickle = SoSPickleDatasetsConnector
     Local_repository = LocalRepositoryDatasetsConnector
     Bigquery = BigqueryDatasetsConnector
+    HDF5 = HDF5DatasetsConnector
 
     @classmethod
     def get_enum_value(cls, value_str):

--- a/sostrades_core/datasets/datasets_connectors/hdf5_datasets_connector.py
+++ b/sostrades_core/datasets/datasets_connectors/hdf5_datasets_connector.py
@@ -1,0 +1,176 @@
+'''
+Copyright 2024 Capgemini
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+'''
+import logging
+import os
+import h5py
+from typing import Any
+
+from sostrades_core.datasets.dataset_info.abstract_dataset_info import AbstractDatasetInfo
+from sostrades_core.datasets.dataset_info.dataset_info_v0 import DatasetInfoV0
+from sostrades_core.datasets.datasets_connectors.abstract_datasets_connector import (
+    AbstractDatasetsConnector,
+    DatasetGenericException,
+    DatasetNotFoundException,
+)
+
+
+class HDF5DatasetsConnector(AbstractDatasetsConnector):
+    """
+    Specific dataset connector for dataset in HDF5 format
+    """
+    VALUE_STR = "value"
+
+    def __init__(self, connector_id: str, file_path: str):
+        """
+        Constructor for HDF5 data connector
+
+        :param file_path: file_path for this dataset connector
+        :type file_path: str
+        """
+        super().__init__()
+        self.__file_path = file_path
+        self.__logger = logging.getLogger(__name__)
+        self.__logger.debug("Initializing HDF5 connector")
+        self.connector_id = connector_id
+
+    def _get_values(self, dataset_identifier: AbstractDatasetInfo, data_to_get: dict[str:str]) -> dict[str:Any]:
+        """
+        Method to retrieve data from HDF5 and fill a data_dict
+
+        :param dataset_identifier: identifier of the dataset
+        :type dataset_identifier: DatasetInfo
+
+        :param data_to_get: data to retrieve, dict of names and types
+        :type data_to_get: dict[str:str]
+        """
+        self.__logger.debug(f"Getting values {data_to_get.keys()} for dataset {dataset_identifier.dataset_id} for connector {self}")
+
+        if not os.path.exists(self.__file_path):
+            raise DatasetNotFoundException(dataset_identifier.dataset_id)
+
+        with h5py.File(self.__file_path, "r") as file:
+            if dataset_identifier.dataset_id not in file:
+                raise DatasetNotFoundException(dataset_identifier.dataset_id)
+
+            dataset_group = file[dataset_identifier.dataset_id]
+            result_data = {key: dataset_group[key][()] for key in data_to_get if key in dataset_group}
+
+        self.__logger.debug(f"Values obtained {list(result_data.keys())} for dataset {dataset_identifier.dataset_id} for connector {self}")
+        return result_data
+
+    def _write_values(self, dataset_identifier: AbstractDatasetInfo, values_to_write: dict[str:Any], data_types_dict: dict[str:str]) -> dict[str: Any]:
+        """
+        Method to write data
+
+        :param dataset_identifier: dataset identifier for connector
+        :type dataset_identifier: DatasetInfo
+        :param values_to_write: dict of data to write {name: value}
+        :type values_to_write: Dict[str:Any]
+        :param data_types_dict: dict of data type {name: type}
+        :type data_types_dict: dict[str:str]
+        """
+        self.__logger.debug(f"Writing values in dataset {dataset_identifier.dataset_id} for connector {self}")
+
+        with h5py.File(self.__file_path, "a") as file:
+            if dataset_identifier.dataset_id not in file:
+                dataset_group = file.create_group(dataset_identifier.dataset_id)
+            else:
+                dataset_group = file[dataset_identifier.dataset_id]
+
+            for key, value in values_to_write.items():
+                if key in dataset_group:
+                    del dataset_group[key]
+                dataset_group.create_dataset(key, data=value)
+
+        return values_to_write
+
+    def _get_values_all(self, dataset_identifier: AbstractDatasetInfo, data_types_dict: dict[str:str]) -> dict[str:Any]:
+        """
+        Get all values from a dataset for HDF5
+        :param dataset_identifier: dataset identifier for connector
+        :type dataset_identifier: DatasetInfo
+        :param data_types_dict: dict of data type {name: type}
+        :type data_types_dict: dict[str:str]
+        """
+        self.__logger.debug(f"Getting all values for dataset {dataset_identifier.dataset_id} for connector {self}")
+
+        if not os.path.exists(self.__file_path):
+            raise DatasetNotFoundException(dataset_identifier.dataset_id)
+
+        with h5py.File(self.__file_path, "r") as file:
+            if dataset_identifier.dataset_id not in file:
+                raise DatasetNotFoundException(dataset_identifier.dataset_id)
+
+            dataset_group = file[dataset_identifier.dataset_id]
+            result_data = {key: dataset_group[key][()] for key in dataset_group}
+
+        return result_data
+
+    def get_datasets_available(self) -> list[AbstractDatasetInfo]:
+        """
+        Get all available datasets for a specific API
+        """
+        self.__logger.debug(f"Getting all datasets for connector {self}")
+
+        if not os.path.exists(self.__file_path):
+            return []
+
+        with h5py.File(self.__file_path, "r") as file:
+            dataset_ids = list(file.keys())
+
+        return [DatasetInfoV0(self.connector_id, dataset_id) for dataset_id in dataset_ids]
+
+    def _write_dataset(
+        self,
+        dataset_identifier: AbstractDatasetInfo,
+        values_to_write: dict[str:Any],
+        data_types_dict: dict[str:str],
+        create_if_not_exists: bool = True,
+        override: bool = False,
+    ) -> dict[str: Any]:
+        """
+        Write a dataset from HDF5
+        :param dataset_identifier: dataset identifier for connector
+        :type dataset_identifier: DatasetInfo
+        :param values_to_write: dict of data to write {name: value}
+        :type values_to_write: dict[str:Any]
+        :param data_types_dict: dict of data types {name: type}
+        :type data_types_dict: dict[str:str]
+        :param create_if_not_exists: create the dataset if it does not exists (raises otherwise)
+        :type create_if_not_exists: bool
+        :param override: override dataset if it exists (raises otherwise)
+        :type override: bool
+        """
+        self.__logger.debug(
+            f"Writing dataset {dataset_identifier.dataset_id} for connector {self} (override={override}, create_if_not_exists={create_if_not_exists})"
+        )
+
+        with h5py.File(self.__file_path, "a") as file:
+            if dataset_identifier.dataset_id not in file:
+                if create_if_not_exists:
+                    dataset_group = file.create_group(dataset_identifier.dataset_id)
+                else:
+                    raise DatasetNotFoundException(dataset_identifier.dataset_id)
+            else:
+                dataset_group = file[dataset_identifier.dataset_id]
+                if override:
+                    for key in dataset_group.keys():
+                        del dataset_group[key]
+
+            for key, value in values_to_write.items():
+                dataset_group.create_dataset(key, data=value)
+
+        return values_to_write


### PR DESCRIPTION
Fixes #2

Add a new dataset connector with format hdf5.

* **New HDF5DatasetsConnector**:
  - Add `HDF5DatasetsConnector` class in `sostrades_core/datasets/datasets_connectors/hdf5_datasets_connector.py`.
  - Implement methods for reading and writing datasets in HDF5 format.
  - Ensure compatibility with `AbstractDatasetsConnector`.

* **DatasetsConnectorFactory**:
  - Add `HDF5DatasetsConnector` to `DatasetConnectorType` enum.
  - Update `get_connector` method to handle `HDF5DatasetsConnector`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/ggoyon/sostrades-core/issues/2?shareId=1cebde83-7c63-4c0d-845b-372c9051dd47).