### PR TITLE
Improve docstrings in auto_complete_headers.py

### DIFF
--- a/sostrades_core/auto_complete_headers.py
+++ b/sostrades_core/auto_complete_headers.py
@@ -14,22 +14,17 @@ See the License for the specific language governing permissions and
 limitations under the License.
 '''
 import json
-
 from sostrades_core.tools.check_headers import HeaderTools
 
-# read local headers_ignore_config.json specific to each repository
-
-if __name__ == "__main__":
+def main() -> None:
+    """
+    Main function to read the headers_ignore_config.json file and write headers if needed in the repository.
+    """
     try:
-
         with open("./headers_ignore_config.json", "r", encoding="utf-8") as f:
-
             headers_ignore_config = json.load(f)
-
             ht = HeaderTools()
-
             ht.set_verbose_mode(False)
-
             ht.write_headers_if_needed_in_repo(
                 headers_ignore_config["extension_to_ignore"],
                 headers_ignore_config["files_to_ignore"],
@@ -39,3 +34,6 @@ if __name__ == "__main__":
     except FileNotFoundError as ex:
         print("headers_ignore_config.json must be available where this command is launched")
         raise ex
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Fixes #9

Add missing docstrings, update existing docstrings to Google format, and add type annotations to function signatures in `sostrades_core/auto_complete_headers.py`.

* Add docstring for the `main` function.
* Add type annotation to the `main` function signature.
* Move the `if __name__ == "__main__":` block to call the `main` function.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/ggoyon/sostrades-core/issues/9?shareId=6fda5eb9-1fcf-469a-b281-c6c563fe4cf9).