### PR TITLE
Improve docstrings in local_filesystem_datasets_connectorV1.py

### DIFF
--- a/sostrades_core/datasets/datasets_connectors/local_filesystem_datasets_connector/local_filesystem_datasets_connectorV1.py
+++ b/sostrades_core/datasets/datasets_connectors/local_filesystem_datasets_connector/local_filesystem_datasets_connectorV1.py
@@ -45,13 +45,11 @@ class LocalFileSystemDatasetsConnectorV1(AbstractDatasetsConnector):
         """
         Constructor for Local Filesystem data connector
 
-
-        :param root_directory_path: root directory path for this dataset connector using filesystem
-        :type root_directory_path: str
-        :param create_if_not_exists: whether to create the root directory if it does not exist
-        :type create_if_not_exists: bool
-        :param serializer_type: type of serializer to deserialize data from connector
-        :type serializer_type: DatasetSerializerType (JSON for jsonDatasetSerializer)
+        Args:
+            connector_id (str): Identifier for the connector.
+            root_directory_path (str): Root directory path for this dataset connector using filesystem.
+            create_if_not_exists (bool): Whether to create the root directory if it does not exist.
+            serializer_type (DatasetSerializerType): Type of serializer to deserialize data from connector.
         """
         super().__init__()
         self._root_directory_path = os.path.abspath(root_directory_path)
@@ -70,9 +68,15 @@ class LocalFileSystemDatasetsConnectorV1(AbstractDatasetsConnector):
         self.connector_id = connector_id
         self.compatible_dataset_info_version = [VERSION_V1]
 
-    def __load_dataset_descriptor(self, dataset_id: str) -> dict[str: dict[str: Any]]:
+    def __load_dataset_descriptor(self, dataset_id: str) -> dict[str, dict[str, Any]]:
         """
         Deal with all directories for the connector and read dataset_descriptor
+
+        Args:
+            dataset_id (str): Identifier of the dataset.
+
+        Returns:
+            dict[str, dict[str, Any]]: Dataset descriptor.
         """
         filesystem_dataset_identifier = self._datasets_serializer.format_filesystem_name(dataset_id)
         if filesystem_dataset_identifier != dataset_id:
@@ -88,15 +92,16 @@ class LocalFileSystemDatasetsConnectorV1(AbstractDatasetsConnector):
         return self._datasets_serializer.read_descriptor_file(dataset_id, dataset_descriptor_path)
 
 
-    def _get_values(self, dataset_identifier: DatasetInfoV1, data_to_get: dict[str:str]) -> dict[str:Any]:
+    def _get_values(self, dataset_identifier: DatasetInfoV1, data_to_get: dict[str, str]) -> dict[str, Any]:
         """
         Method to retrieve data from local dataset and fill a data_dict
 
-        :param dataset_identifier: identifier of the dataset
-        :type dataset_identifier: DatasetInfo
+        Args:
+            dataset_identifier (DatasetInfoV1): Identifier of the dataset.
+            data_to_get (dict[str, str]): Data to retrieve, dict of names and types.
 
-        :param data_to_get: data to retrieve, dict of names and types
-        :type data_to_get: dict[str:str]
+        Returns:
+            dict[str, Any]: Retrieved data.
         """
         self._logger.debug(f"Getting values {data_to_get.keys()} for dataset {dataset_identifier.dataset_id}, dataset group {dataset_identifier.group_id}, for connector {self}")
 
@@ -124,23 +129,26 @@ class LocalFileSystemDatasetsConnectorV1(AbstractDatasetsConnector):
     def get_datasets_available(self) -> list[DatasetInfoV1]:
         """
         Get all available datasets for a specific API
-        :return: list of datasets identifiers
+
+        Returns:
+            list[DatasetInfoV1]: List of datasets identifiers.
         """
         self._logger.debug(f"Getting all datasets for connector {self}")
         return [DatasetInfoV1(self.connector_id, dataset_id, group_id)
                 for dataset_id in next(os.walk(self._root_directory_path))[1]
                 for group_id in next(os.walk(self.__build_dataset_path(dataset_id)))[1]]
 
-    def _write_values(self, dataset_identifier: DatasetInfoV1, values_to_write: dict[str:Any], data_types_dict: dict[str:str]) -> dict[str: Any]:
+    def _write_values(self, dataset_identifier: DatasetInfoV1, values_to_write: dict[str, Any], data_types_dict: dict[str, str]) -> dict[str, Any]:
         """
         Method to write data
-        :param dataset_identifier: dataset identifier for connector
-        :type dataset_identifier: DatasetInfo
-        :param values_to_write: dict of data to write {name: value}
-        :type values_to_write: dict[str], name, value
-        :param data_types_dict: dict of data type {name: type}
-        :type data_types_dict: dict[str:str]
-        :return: None
+
+        Args:
+            dataset_identifier (DatasetInfoV1): Identifier of the dataset.
+            values_to_write (dict[str, Any]): Dict of data to write {name: value}.
+            data_types_dict (dict[str, str]): Dict of data type {name: type}.
+
+        Returns:
+            dict[str, Any]: Written values.
         """
         self._logger.debug(f"Writing values in dataset {dataset_identifier.dataset_id} for connector {self}")
 
@@ -174,14 +182,16 @@ class LocalFileSystemDatasetsConnectorV1(AbstractDatasetsConnector):
         self._datasets_serializer.dump_pickle_data()
         return values_to_write
 
-    def _get_values_all(self, dataset_identifier: DatasetInfoV1, data_types_dict: dict[str:str]) -> dict[str:Any]:
+    def _get_values_all(self, dataset_identifier: DatasetInfoV1, data_types_dict: dict[str, str]) -> dict[str, Any]:
         """
         Abstract method to get all values from a dataset for a specific API
-        :param dataset_identifier: dataset identifier for connector
-        :type dataset_identifier: DatasetInfo
-        :param data_types_dict: dict of data type {name: type}
-        :type data_types_dict: dict[str:str]
-        :return: None
+
+        Args:
+            dataset_identifier (DatasetInfoV1): Identifier of the dataset.
+            data_types_dict (dict[str, str]): Dict of data type {name: type}.
+
+        Returns:
+            dict[str, Any]: All values from the dataset.
         """
         dataset_descriptor = self.__load_dataset_descriptor(dataset_identifier.dataset_id)
         dataset_values = dict()
@@ -198,20 +208,16 @@ class LocalFileSystemDatasetsConnectorV1(AbstractDatasetsConnector):
         self._datasets_serializer.clear_pickle_data()
         return dataset_values
 
-    def _write_dataset(self, dataset_identifier: DatasetInfoV1, values_to_write: dict[str:Any], data_types_dict: dict[str:str], create_if_not_exists: bool = True, override: bool = False) -> None:
+    def _write_dataset(self, dataset_identifier: DatasetInfoV1, values_to_write: dict[str, Any], data_types_dict: dict[str, str], create_if_not_exists: bool = True, override: bool = False) -> None:
         """
         Abstract method to overload in order to write a dataset from a specific API
-        :param dataset_identifier: dataset identifier for connector
-        :type dataset_identifier: DatasetInfo
-        :param values_to_write: dict of data to write {name: value}
-        :type values_to_write: dict[str:Any]
-        :param data_types_dict: dict of data types {name: type}
-        :type data_types_dict: dict[str:str]
-        :param create_if_not_exists: create the dataset if it does not exists (raises otherwise)
-        :type create_if_not_exists: bool
-        :param override: override dataset if it exists (raises otherwise)
-        :type override: bool
-        :return: None
+
+        Args:
+            dataset_identifier (DatasetInfoV1): Identifier of the dataset.
+            values_to_write (dict[str, Any]): Dict of data to write {name: value}.
+            data_types_dict (dict[str, str]): Dict of data types {name: type}.
+            create_if_not_exists (bool): Create the dataset if it does not exists (raises otherwise).
+            override (bool): Override dataset if it exists (raises otherwise).
         """
         self._logger.debug(f"Writing dataset {dataset_identifier.dataset_id} for connector {self} (override={override}, create_if_not_exists={create_if_not_exists})")
 
@@ -238,9 +244,9 @@ class LocalFileSystemDatasetsConnectorV1(AbstractDatasetsConnector):
     def clear(self, remove_root_directory: bool = False) -> None:
         """
         Utility method to remove all datasets in the connector root directory.
-        :param remove_root_directory: whether to delete the root directory itself too.
-        :type remove_root_directory: bool
-        :return: None
+
+        Args:
+            remove_root_directory (bool): Whether to delete the root directory itself too.
         """
         if remove_root_directory:
             rmtree_safe(self._root_directory_path)
@@ -250,18 +256,30 @@ class LocalFileSystemDatasetsConnectorV1(AbstractDatasetsConnector):
     def clear_dataset(self, dataset_id: str) -> None:
         """
         Utility method to remove the directory corresponding to a given dataset_id within the root directory.
-        :param dataset_id: identifier of the dataset to be removed
-        :type dataset_id: str
-        :return: None
+
+        Args:
+            dataset_id (str): Identifier of the dataset to be removed.
         """
         rmtree_safe(os.path.join(self._root_directory_path, dataset_id))
 
 
     def __index_data_group_directory(self,
-                                     dataset_descriptor,
-                                     dataset_identifier,
-                                     data_group_identifier,
-                                     filesystem_data_group_identifier):
+                                     dataset_descriptor: dict[str, dict[str, Any]],
+                                     dataset_identifier: str,
+                                     data_group_identifier: str,
+                                     filesystem_data_group_identifier: str) -> dict[str, dict[str, Any]]:
+        """
+        Index the data group directory.
+
+        Args:
+            dataset_descriptor (dict[str, dict[str, Any]]): Dataset descriptor.
+            dataset_identifier (str): Identifier of the dataset.
+            data_group_identifier (str): Identifier of the data group.
+            filesystem_data_group_identifier (str): Filesystem identifier of the data group.
+
+        Returns:
+            dict[str, dict[str, Any]]: Updated dataset descriptor.
+        """
         if filesystem_data_group_identifier != data_group_identifier:
             dataset_descriptor[data_group_identifier][self.DATA_GROUP_DIRECTORY_KEY] = filesystem_data_group_identifier
             existing_group_dirs = {dataset_descriptor[_group_id].get(self.DATA_GROUP_DIRECTORY_KEY, _group_id): _group_id
@@ -274,9 +292,20 @@ class LocalFileSystemDatasetsConnectorV1(AbstractDatasetsConnector):
         return dataset_descriptor
 
     def __get_data_group_directory(self,
-                                   dataset_descriptor,
-                                   dataset_identifier,
-                                   data_group_identifier):
+                                   dataset_descriptor: dict[str, dict[str, Any]],
+                                   dataset_identifier: str,
+                                   data_group_identifier: str) -> str:
+        """
+        Get the data group directory.
+
+        Args:
+            dataset_descriptor (dict[str, dict[str, Any]]): Dataset descriptor.
+            dataset_identifier (str): Identifier of the dataset.
+            data_group_identifier (str): Identifier of the data group.
+
+        Returns:
+            str: Data group directory.
+        """
         data_group_dir = dataset_descriptor[data_group_identifier].get(self.DATA_GROUP_DIRECTORY_KEY, data_group_identifier)
         formatted_data_group_dir = self._datasets_serializer.format_filesystem_name(data_group_dir)
         if data_group_dir != formatted_data_group_dir:
@@ -285,20 +314,39 @@ class LocalFileSystemDatasetsConnectorV1(AbstractDatasetsConnector):
                                 f"{data_group_identifier}, using compliant {formatted_data_group_dir} instead")
         return formatted_data_group_dir
 
-    def __build_descriptor_file_path(self, dataset_id:str)->str:
+    def __build_descriptor_file_path(self, dataset_id: str) -> str:
         """
-        build the dataset descriptor file path that is in the dataset
+        Build the dataset descriptor file path that is in the dataset.
+
+        Args:
+            dataset_id (str): Identifier of the dataset.
+
+        Returns:
+            str: Dataset descriptor file path.
         """
         return os.path.join(self.__build_dataset_path(dataset_id), self.DESCRIPTOR_FILE_NAME)
 
-    def __build_dataset_path(self, dataset_id:str)->str:
+    def __build_dataset_path(self, dataset_id: str) -> str:
         """
-        build the dataset foler path that is in the root folder of the connector
+        Build the dataset folder path that is in the root folder of the connector.
+
+        Args:
+            dataset_id (str): Identifier of the dataset.
+
+        Returns:
+            str: Dataset folder path.
         """
         return os.path.join(self._root_directory_path, dataset_id)
 
-    def __build_group_path(self, dataset_id:str, group_name:str)->str:
+    def __build_group_path(self, dataset_id: str, group_name: str) -> str:
         """
-        build the dataset descriptor file path that is in the dataset
+        Build the dataset descriptor file path that is in the dataset.
+
+        Args:
+            dataset_id (str): Identifier of the dataset.
+            group_name (str): Name of the group.
+
+        Returns:
+            str: Group path.
         """
         return os.path.join(self._root_directory_path, dataset_id, group_name)


### PR DESCRIPTION
Fixes #37

Add missing docstrings, update existing docstrings to Google format, and add type annotations to function signatures in `sostrades_core/datasets/datasets_connectors/local_filesystem_datasets_connector/local_filesystem_datasets_connectorV1.py`.

* **Docstrings**:
  - Add missing docstrings to methods: `__load_dataset_descriptor`, `__index_data_group_directory`, `__get_data_group_directory`, `__build_descriptor_file_path`, `__build_dataset_path`, and `__build_group_path`.
  - Update existing docstrings to follow Google format.

* **Type Annotations**:
  - Add type annotations to function signatures for parameters and return types in methods: `__load_dataset_descriptor`, `_get_values`, `get_datasets_available`, `_write_values`, `_get_values_all`, `_write_dataset`, `clear`, `clear_dataset`, `__index_data_group_directory`, `__get_data_group_directory`, `__build_descriptor_file_path`, `__build_dataset_path`, and `__build_group_path`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/ggoyon/sostrades-core/pull/82?shareId=90d2b3fb-5189-42c5-9594-556263e09b31).