### PR TITLE
Improve docstrings in datasets_serializer_factory.py

### DIFF
--- a/sostrades_core/datasets/datasets_serializers/datasets_serializer_factory.py
+++ b/sostrades_core/datasets/datasets_serializers/datasets_serializer_factory.py
@@ -15,6 +15,7 @@ limitations under the License.
 '''
 import logging
 from enum import Enum
+from typing import Type
 
 from sostrades_core.datasets.datasets_serializers.abstract_datasets_serializer import (
     AbstractDatasetsSerializer,
@@ -41,7 +42,19 @@ class DatasetSerializerType(Enum):
     BigQuery = BigQueryDatasetsSerializer
 
     @classmethod
-    def get_enum_value(cls, value_str):
+    def get_enum_value(cls, value_str: str) -> DatasetSerializerType:
+        """
+        Get the enum value corresponding to the given string.
+
+        Args:
+            value_str (str): The string representation of the enum value.
+
+        Returns:
+            DatasetSerializerType: The corresponding enum value.
+
+        Raises:
+            ValueError: If no matching enum value is found.
+        """
         try:
             # Iterate through the enum members and find the one with a matching value
             return next(member for member in cls if member.name == value_str)
@@ -56,17 +69,22 @@ class DatasetsSerializerFactory(metaclass=NoInstanceMeta):
     __logger = logging.getLogger(__name__)
 
     @classmethod
-    def get_serializer(cls,
-        serializer_type: DatasetSerializerType
-    ) -> AbstractDatasetsSerializer:
+    def get_serializer(cls, serializer_type: DatasetSerializerType) -> AbstractDatasetsSerializer:
         """
-        Instanciate a serializer of type serializer_type with provided arguments
-        Raises ValueError if type is invalid
+        Instantiate a serializer of type serializer_type with provided arguments.
+        Raises ValueError if type is invalid.
 
-        :param serializer_type: serializer type to instanciate
-        :type serializer_type: DatasetserializerType
+        Args:
+            serializer_type (DatasetSerializerType): The serializer type to instantiate.
+
+        Returns:
+            AbstractDatasetsSerializer: The instantiated serializer.
+
+        Raises:
+            ValueError: If the serializer type is unexpected.
+            Exception: If there is an error during instantiation.
         """
-        cls.__logger.debug(f"Instanciating serializer of type {serializer_type}")
+        cls.__logger.debug(f"Instantiating serializer of type {serializer_type}")
         if not isinstance(serializer_type, DatasetSerializerType) or not issubclass(
             serializer_type.value, AbstractDatasetsSerializer
         ):


### PR DESCRIPTION
Fixes #41

Update `sostrades_core/datasets/datasets_serializers/datasets_serializer_factory.py` to improve docstrings and add type annotations.

* Add missing docstrings in Google format for `get_enum_value` and `get_serializer` methods.
* Update existing docstrings to Google format for `get_serializer` method.
* Add type annotations to function signatures for `get_enum_value` and `get_serializer` methods.
* Fix typo in debug log message from "Instanciating" to "Instantiating".

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/ggoyon/sostrades-core/pull/85?shareId=6c2999b4-d684-4d7f-bc40-30320b34f73c).