### PR TITLE
Improve docstrings in dataset_info_v0.py

### DIFF
--- a/sostrades_core/datasets/dataset_info/dataset_info_v0.py
+++ b/sostrades_core/datasets/dataset_info/dataset_info_v0.py
@@ -36,16 +36,29 @@ class DatasetInfoV0(AbstractDatasetInfo):
 
     @property
     def version_id(self) -> str:
+        """
+        Returns the version ID of the dataset.
+
+        Returns:
+            str: The version ID of the dataset.
+        """
         return VERSION_V0
 
     @staticmethod
-    def deserialize(dataset_mapping_key:str) -> dict[str,str]:
+    def deserialize(dataset_mapping_key: str) -> dict[str, str]:
         """
         Method to deserialize
         expected
         'vx(optional)|'<connector_id>|<dataset_id>|<parameter_id> (for V0)
-        :param dataset_mapping_key: datasets informations of mapping dataset
-        :type dataset_mapping_key: str
+
+        Args:
+            dataset_mapping_key (str): datasets informations of mapping dataset
+
+        Returns:
+            dict[str, str]: A dictionary containing the deserialized dataset information.
+
+        Raises:
+            DatasetsInfoMappingException: If the dataset name is '*'.
         """
         # check if the version is in the mapping key or not
         input_dict = DatasetInfoV0.extract_mapping_key_field(dataset_mapping_key, DatasetInfoV0.MAPPING_ITEM_FIELDS)
@@ -53,19 +66,32 @@ class DatasetInfoV0(AbstractDatasetInfo):
             raise DatasetsInfoMappingException(f"Wrong format for V0 mapping key {dataset_mapping_key}, the dataset name '*' is not authorised")
         return input_dict
 
-
     @staticmethod
-    def create(input_dict: dict) -> DatasetInfoV0:
+    def create(input_dict: dict[str, str]) -> DatasetInfoV0:
+        """
+        Method to create a DatasetInfoV0 instance.
 
+        Args:
+            input_dict (dict[str, str]): A dictionary containing the dataset information.
+
+        Returns:
+            DatasetInfoV0: An instance of DatasetInfoV0.
+        """
         return DatasetInfoV0(
             connector_id=input_dict[DatasetInfoV0.CONNECTOR_ID_KEY],
             dataset_id=input_dict[DatasetInfoV0.DATASET_ID_KEY]
         )
 
-    def copy_with_new_ns(self, associated_namespace:str)-> AbstractDatasetInfo:
-        '''
-        overrided method
-        '''
+    def copy_with_new_ns(self, associated_namespace: str) -> AbstractDatasetInfo:
+        """
+        Overrided method to create a copy of the dataset info with a new namespace.
+
+        Args:
+            associated_namespace (str): The new namespace to associate with the dataset info.
+
+        Returns:
+            AbstractDatasetInfo: A new instance of DatasetInfoV0 with the updated namespace.
+        """
         # there is no need to update ns in this dataset info version
         return DatasetInfoV0(
             connector_id=self.connector_id,
@@ -73,8 +99,20 @@ class DatasetInfoV0(AbstractDatasetInfo):
         )
 
     @classmethod
-    def extract_mapping_key_field(cls, dataset_mapping_key: str, dataset_mapping_fields: list[str])-> dict[str: str]:
+    def extract_mapping_key_field(cls, dataset_mapping_key: str, dataset_mapping_fields: list[str]) -> dict[str, str]:
+        """
+        Extracts the fields from the dataset mapping key.
 
+        Args:
+            dataset_mapping_key (str): The dataset mapping key.
+            dataset_mapping_fields (list[str]): The list of dataset mapping fields.
+
+        Returns:
+            dict[str, str]: A dictionary containing the extracted fields.
+
+        Raises:
+            ValueError: If the format of the dataset mapping key is incorrect.
+        """
         # check if there is a version in the key, if not it is V0
         if not (dataset_mapping_key.startswith(f'V0{cls.SEPARATOR}') or dataset_mapping_key.startswith(f'v0{cls.SEPARATOR}')):
             dataset_mapping_key = f'{VERSION_V0}{cls.SEPARATOR}{dataset_mapping_key}'


### PR DESCRIPTION
Fixes #47

Add missing docstrings, update existing docstrings to Google format, and add type annotations to function signatures in `sostrades_core/datasets/dataset_info/dataset_info_v0.py`.

* **Docstrings**:
  - Add docstrings for `version_id`, `deserialize`, `create`, `copy_with_new_ns`, and `extract_mapping_key_field` methods.
  - Update existing docstrings to Google format.

* **Type Annotations**:
  - Add type annotations to function signatures for `deserialize`, `create`, `copy_with_new_ns`, and `extract_mapping_key_field` methods.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/ggoyon/sostrades-core/pull/90?shareId=839457df-4df8-457f-9fdf-a835d208aad9).